### PR TITLE
Update tips.mdx

### DIFF
--- a/docs/configuration/tips.mdx
+++ b/docs/configuration/tips.mdx
@@ -58,7 +58,7 @@ The `position_precision` setting allows control of the level of precision for lo
 For detailed information on position precision settings and how to configure them, please refer to the [Position Precision documentation](/docs/configuration/radio/channels/#position-precision).
 
 ### Sharing Location on a Private Secondary Channel
-> This is a newer feature that only works for firmware 2.6.10+
+> This is a newer feature that only works for firmware 2.7.1+
 
 To share your location on a private secondary channel while keeping the default primary channel unencrypted, follow these steps:
 


### PR DESCRIPTION
"Sharing Location on a Private Secondary Channel" isn't implemented until 2.7.0, which was pulled in favor of 2.7.1. Updating to reflect 2.7.1+ #6838 is where this code was merged.

<!-- Add or remove sections as needed -->
## What did you change
Had been testing per docs using 2.6.11 to share location on a private secondary channel and was not working. 2.7.7 worked, and code shows implemented initially in 2.7.0. Updating to reflect 2.7.1 as minimum release version.
<!-- Describe what your changes will do if merged -->
Update documentation to more appropriately reflect the required minimum firmware version.
## Why did you change it
Incorrect documentation.
<!-- Be sure to link any relevant changes such as other PRs, issues, or Discord convos -->
Ref #6838
## Screenshots
### Before


### After
